### PR TITLE
Fix compile errors without Input System package

### DIFF
--- a/Assets/Scripts/Combat/CombatInput.cs
+++ b/Assets/Scripts/Combat/CombatInput.cs
@@ -1,21 +1,30 @@
 using UnityEngine;
+#if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
+#endif
 
 namespace MMO.Combat
 {
+#if ENABLE_INPUT_SYSTEM
     [RequireComponent(typeof(PlayerInput))]
+#endif
     public class CombatInput : MonoBehaviour
     {
+#if ENABLE_INPUT_SYSTEM
         public PlayerInput PlayerInput { get; private set; }
+#endif
 
         public event System.Action<int> OnAbilityPressed;
         public event System.Action OnTargetNext;
 
+#if ENABLE_INPUT_SYSTEM
         private void Awake()
         {
             PlayerInput = GetComponent<PlayerInput>();
         }
+#endif
 
+#if ENABLE_INPUT_SYSTEM
         public void OnAbility1(InputAction.CallbackContext context)
         {
             if (context.performed)
@@ -51,5 +60,23 @@ namespace MMO.Combat
             if (context.performed)
                 OnTargetNext?.Invoke();
         }
+#else
+        private void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.Alpha1))
+                OnAbilityPressed?.Invoke(1);
+            if (Input.GetKeyDown(KeyCode.Alpha2))
+                OnAbilityPressed?.Invoke(2);
+            if (Input.GetKeyDown(KeyCode.Alpha3))
+                OnAbilityPressed?.Invoke(3);
+            if (Input.GetKeyDown(KeyCode.Alpha4))
+                OnAbilityPressed?.Invoke(4);
+            if (Input.GetKeyDown(KeyCode.Alpha5))
+                OnAbilityPressed?.Invoke(5);
+
+            if (Input.GetKeyDown(KeyCode.Tab))
+                OnTargetNext?.Invoke();
+        }
+#endif
     }
 }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Assets/
 
 1. **Create Scene**: Open Unity and create a scene named `Main` in `Assets/Scenes`. Add a flat terrain and a directional light. 
 2. **Player Controller**: Import the `Starter Assets – Third Person Controller` package and add the prefab to the scene. Replace the capsule with a humanoid rig and ensure a `CharacterController`, `Rigidbody`, `Animator`, and `PlayerInput` component are present. Use Cinemachine or the included camera rig for camera follow.
-3. **Input System**: Create an `Input Actions` asset named `PlayerControls` in `Assets/Settings` with actions `Move`, `Look`, `Jump`, `TargetNext`, `Ability1`‑`Ability5`. Bind them for both keyboard/mouse and gamepad. Hook these callbacks to `CombatInput`.
+3. **Input System**: Install the `Input System` package from the Package Manager and enable it in Project Settings. Then create an `Input Actions` asset named `PlayerControls` in `Assets/Settings` with actions `Move`, `Look`, `Jump`, `TargetNext`, `Ability1`‑`Ability5`. Bind them for both keyboard/mouse and gamepad. Hook these callbacks to `CombatInput`.
 4. **Scripts**: Attach the provided scripts as needed.
 
 The client is intended to communicate with an Elixir/Phoenix backend using UDP and WebSockets.


### PR DESCRIPTION
## Summary
- guard `CombatInput` with `ENABLE_INPUT_SYSTEM` so it can compile when the Input System package isn't installed
- add simple keyboard fallback controls
- update README to mention installing the Input System package

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fd15838b08331831956af91faffc5