### PR TITLE
Add MMO camera input actions asset

### DIFF
--- a/Assets/InputActions.inputactions
+++ b/Assets/InputActions.inputactions
@@ -1,0 +1,88 @@
+{
+    "name": "InputActions",
+    "maps": [
+        {
+            "name": "Camera",
+            "id": "2ad65171-11ee-4c6c-bb2c-7e1f7e9e6f8d",
+            "actions": [
+                {
+                    "name": "lookAction",
+                    "type": "Value",
+                    "id": "3e9af0bc-24a1-4d78-8ce5-fef3a73e2787",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "orbitAction",
+                    "type": "Button",
+                    "id": "b23143f9-2592-4ba0-9dda-adb14bf77a3f",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "zoomAction",
+                    "type": "Value",
+                    "id": "b857b458-dbd8-4dbe-8c25-4e709e9c54d6",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": ""
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "6cca29ad-aef5-43fd-b3fd-b283dd0ae0b5",
+                    "path": "<Mouse>/delta",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "lookAction",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "dd933fc7-4d4e-4a09-8e25-717a8e52eb20",
+                    "path": "<Mouse>/rightButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "orbitAction",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "279a8b32-efaa-4479-aeae-41ad27c7f984",
+                    "path": "<Mouse>/scroll",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KeyboardMouse",
+                    "action": "zoomAction",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        }
+    ],
+    "controlSchemes": [
+        {
+            "name": "KeyboardMouse",
+            "bindingGroup": "KeyboardMouse",
+            "devices": [
+                {
+                    "devicePath": "<Keyboard>",
+                    "isOptional": false,
+                    "isOR": false
+                },
+                {
+                    "devicePath": "<Mouse>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        }
+    ]
+}

--- a/Assets/InputActions.inputactions.meta
+++ b/Assets/InputActions.inputactions.meta
@@ -1,0 +1,14 @@
+fileFormatVersion: 2
+guid: e0fac10f68c6454099ee1170aa7433ff
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: 8404be70184654265930450def6a9037, type: 3}
+  generateWrapperCode: 0
+  wrapperCodePath:
+  wrapperClassName:
+  wrapperCodeNamespace:


### PR DESCRIPTION
## Summary
- create `InputActions.inputactions` for MMO-style camera control
- map includes lookAction, orbitAction, and zoomAction with mouse bindings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870254078388331a5280aa0f6e62594