### PR TITLE
Fix Cinemachine duplication in camera controller

### DIFF
--- a/Assets/Scripts/Camera/MMOCameraController.cs
+++ b/Assets/Scripts/Camera/MMOCameraController.cs
@@ -6,7 +6,7 @@ using UnityEngine.InputSystem;
 
 namespace MMO.Camera
 {
-    [RequireComponent(typeof(CinemachineFreeLook))]
+    [DisallowMultipleComponent]
     public class MMOCameraController : MonoBehaviour
     {
         [SerializeField] private CinemachineFreeLook vcam;
@@ -33,10 +33,31 @@ namespace MMO.Camera
         private bool IsOrbiting => orbitAction != null && orbitAction.action.IsPressed();
 #endif
 
+        private void OnValidate()
+        {
+            if (vcam == null)
+                vcam = GetComponentInChildren<CinemachineFreeLook>();
+            if (followTarget == null && vcam != null)
+                followTarget = vcam.Follow;
+        }
+
         private void Awake()
         {
             if (vcam == null)
-                vcam = GetComponent<CinemachineFreeLook>();
+                vcam = GetComponentInChildren<CinemachineFreeLook>();
+
+            if (vcam == null)
+            {
+                Debug.LogError($"{nameof(MMOCameraController)} requires a CinemachineFreeLook assigned in the Inspector or as a child.", this);
+                enabled = false;
+                return;
+            }
+
+            var cams = GetComponentsInChildren<CinemachineVirtualCameraBase>();
+            if (cams.Length > 1)
+            {
+                Debug.LogError($"{nameof(MMOCameraController)} found multiple CinemachineVirtualCameraBase components. Remove extras to avoid conflicts.", this);
+            }
 
             vcam.m_BindingMode = CinemachineTransposer.BindingMode.WorldSpace;
 


### PR DESCRIPTION
## Summary
- remove `RequireComponent` on `MMOCameraController`
- grab existing `CinemachineFreeLook` from children instead of adding one
- validate camera availability and uniqueness
- add `OnValidate` for inspector assignment

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68710bfb29888331986654bed939ace1