### PR TITLE
Implement UDP movement packet sender

### DIFF
--- a/Assets/Scripts/Networking/PlayerNetworkController.cs
+++ b/Assets/Scripts/Networking/PlayerNetworkController.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using UnityEngine;
+
+namespace MMO.Networking
+{
+    [DisallowMultipleComponent]
+    public class PlayerNetworkController : MonoBehaviour
+    {
+        public int playerId = 1;
+        public string serverIP = "127.0.0.1";
+        public int serverPort = 4000;
+
+        private UdpClient udpClient;
+        private Vector3 lastPosition;
+
+        private void Start()
+        {
+            udpClient = new UdpClient();
+            lastPosition = transform.position;
+        }
+
+        private void Update()
+        {
+            Vector3 currentPosition = transform.position;
+            Vector3 delta = currentPosition - lastPosition;
+            if (delta.sqrMagnitude > 0f)
+            {
+                SendMovement(delta);
+                lastPosition = currentPosition;
+            }
+        }
+
+        private void SendMovement(Vector3 delta)
+        {
+            byte[] packet = new byte[30];
+            int offset = 0;
+
+            int pidNet = IPAddress.HostToNetworkOrder(playerId);
+            short opcodeNet = IPAddress.HostToNetworkOrder((short)1);
+
+            byte[] tmp = BitConverter.GetBytes(pidNet);
+            Buffer.BlockCopy(tmp, 0, packet, offset, 4);
+            offset += 4;
+
+            tmp = BitConverter.GetBytes(opcodeNet);
+            Buffer.BlockCopy(tmp, 0, packet, offset, 2);
+            offset += 2;
+
+            WriteDouble(delta.x, packet, ref offset);
+            WriteDouble(delta.y, packet, ref offset);
+            WriteDouble(delta.z, packet, ref offset);
+
+            udpClient.Send(packet, packet.Length, serverIP, serverPort);
+        }
+
+        private static void WriteDouble(double value, byte[] buffer, ref int offset)
+        {
+            byte[] bytes = BitConverter.GetBytes(value);
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(bytes);
+
+            Buffer.BlockCopy(bytes, 0, buffer, offset, 8);
+            offset += 8;
+        }
+
+        private void OnDestroy()
+        {
+            udpClient?.Close();
+        }
+    }
+}

--- a/Assets/Scripts/Networking/PlayerNetworkController.cs.meta
+++ b/Assets/Scripts/Networking/PlayerNetworkController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f8401551af928abc90b4fcc00195edc7


### PR DESCRIPTION
## Summary
- add `PlayerNetworkController` to send UDP packets with player movement every frame when the player moves
- include `.meta` file for Unity asset tracking

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711bb58a708331bd989ed0b6cd3acc