### PR TITLE
Send fixed size movement packets

### DIFF
--- a/Assets/Scripts/Networking/PlayerNetworkController.cs
+++ b/Assets/Scripts/Networking/PlayerNetworkController.cs
@@ -8,7 +8,7 @@ namespace MMO.Networking
     [DisallowMultipleComponent]
     public class PlayerNetworkController : MonoBehaviour
     {
-        public string playerId = "player1";
+        public int playerId = 1;
         public string serverIP = "127.0.0.1";
         public int serverPort = 4000;
 
@@ -34,28 +34,21 @@ namespace MMO.Networking
 
         private void SendMovement(Vector3 delta)
         {
-            byte[] idBytes = System.Text.Encoding.UTF8.GetBytes(playerId);
-            int packetSize = 4 + idBytes.Length + 2 + 24; // id length, id, opcode, 3 doubles
-            byte[] packet = new byte[packetSize];
+            byte[] packet = new byte[30];
             int offset = 0;
 
-            WriteInt(idBytes.Length, packet, ref offset);
-            Buffer.BlockCopy(idBytes, 0, packet, offset, idBytes.Length);
-            offset += idBytes.Length;
+            WriteInt32(playerId, packet, ref offset);
+            WriteInt16(1, packet, ref offset);
+            WriteFloat64(delta.x, packet, ref offset);
+            WriteFloat64(delta.y, packet, ref offset);
+            WriteFloat64(delta.z, packet, ref offset);
 
-            short opcodeNet = IPAddress.HostToNetworkOrder((short)1);
-            byte[] tmp = BitConverter.GetBytes(opcodeNet);
-            Buffer.BlockCopy(tmp, 0, packet, offset, 2);
-            offset += 2;
-
-            WriteDouble(delta.x, packet, ref offset);
-            WriteDouble(delta.y, packet, ref offset);
-            WriteDouble(delta.z, packet, ref offset);
+            Debug.Log($"Sending movement packet: {BitConverter.ToString(packet)}");
 
             udpClient.Send(packet, packet.Length, serverIP, serverPort);
         }
 
-        private static void WriteInt(int value, byte[] buffer, ref int offset)
+        private static void WriteInt32(int value, byte[] buffer, ref int offset)
         {
             int net = IPAddress.HostToNetworkOrder(value);
             byte[] bytes = BitConverter.GetBytes(net);
@@ -63,7 +56,15 @@ namespace MMO.Networking
             offset += 4;
         }
 
-        private static void WriteDouble(double value, byte[] buffer, ref int offset)
+        private static void WriteInt16(short value, byte[] buffer, ref int offset)
+        {
+            short net = IPAddress.HostToNetworkOrder(value);
+            byte[] bytes = BitConverter.GetBytes(net);
+            Buffer.BlockCopy(bytes, 0, buffer, offset, 2);
+            offset += 2;
+        }
+
+        private static void WriteFloat64(double value, byte[] buffer, ref int offset)
         {
             byte[] bytes = BitConverter.GetBytes(value);
             if (BitConverter.IsLittleEndian)
@@ -72,6 +73,7 @@ namespace MMO.Networking
             Buffer.BlockCopy(bytes, 0, buffer, offset, 8);
             offset += 8;
         }
+
 
         private void OnDestroy()
         {


### PR DESCRIPTION
## Summary
- use `int` player ID instead of a string
- encode movement packets as a fixed 30-byte binary structure
- add helpers for writing int32, int16 and float64 values
- log packet bytes before sending

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687141538d58833181e540fc7f884c5c