### PR TITLE
Fix CanvasRenderer duplication and font for Unity 6.1

### DIFF
--- a/Assets/Scripts/UI/MMOUIBuilder.cs
+++ b/Assets/Scripts/UI/MMOUIBuilder.cs
@@ -101,7 +101,8 @@ namespace MMO.UI
             rt.pivot = new Vector2(0f, 0f);
             rt.anchoredPosition = new Vector2(10f, 10f);
 
-            chat.AddComponent<CanvasRenderer>();
+            if (chat.GetComponent<CanvasRenderer>() == null)
+                chat.AddComponent<CanvasRenderer>();
             ScrollRect scroll = chat.AddComponent<ScrollRect>();
             GameObject viewport = new GameObject("Viewport", typeof(Image), typeof(Mask));
             RectTransform vpRt = viewport.GetComponent<RectTransform>();
@@ -212,7 +213,7 @@ namespace MMO.UI
             go.transform.SetParent(parent, false);
             Text text = go.GetComponent<Text>();
             text.text = name;
-            text.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            text.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
             text.alignment = TextAnchor.MiddleCenter;
         }
 


### PR DESCRIPTION
## Summary
- avoid adding a duplicate CanvasRenderer in `CreateChatWindow`
- load `LegacyRuntime.ttf` instead of the deprecated `Arial.ttf`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687158bbd684833194d941219e36ce8b