### PR TITLE
Change A/D to strafe

### DIFF
--- a/Assets/StarterAssets/ThirdPersonController/Scripts/ThirdPersonController.cs
+++ b/Assets/StarterAssets/ThirdPersonController/Scripts/ThirdPersonController.cs
@@ -248,24 +248,21 @@ namespace StarterAssets
             _animationBlend = Mathf.Lerp(_animationBlend, targetSpeed, Time.deltaTime * SpeedChangeRate);
             if (_animationBlend < 0.01f) _animationBlend = 0f;
 
-            // normalise input direction
+            // convert input direction relative to camera
             Vector3 inputDirection = new Vector3(_input.move.x, 0.0f, _input.move.y).normalized;
+            Vector3 worldDirection = Quaternion.Euler(0.0f, _mainCamera.transform.eulerAngles.y, 0.0f) * inputDirection;
 
-            // note: Vector2's != operator uses approximation so is not floating point error prone, and is cheaper than magnitude
-            // if there is a move input rotate player when the player is moving
-            if (_input.move != Vector2.zero)
+            // rotate to face movement direction only when moving forward
+            if (_input.move.y > Mathf.Epsilon)
             {
-                _targetRotation = Mathf.Atan2(inputDirection.x, inputDirection.z) * Mathf.Rad2Deg +
-                                  _mainCamera.transform.eulerAngles.y;
+                _targetRotation = Mathf.Atan2(worldDirection.x, worldDirection.z) * Mathf.Rad2Deg;
                 float rotation = Mathf.SmoothDampAngle(transform.eulerAngles.y, _targetRotation, ref _rotationVelocity,
                     RotationSmoothTime);
 
-                // rotate to face input direction relative to camera position
                 transform.rotation = Quaternion.Euler(0.0f, rotation, 0.0f);
             }
 
-
-            Vector3 targetDirection = Quaternion.Euler(0.0f, _targetRotation, 0.0f) * Vector3.forward;
+            Vector3 targetDirection = worldDirection;
 
             // move the player
             _controller.Move(targetDirection.normalized * (_speed * Time.deltaTime) +


### PR DESCRIPTION
## Summary
- tweak movement logic so horizontal input strafes instead of turning
- only rotate character when moving forward so S walks backward

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68726218300883318f3cb89446530654